### PR TITLE
fix: use correct path in sbom workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -34,7 +34,6 @@ jobs:
     - name: Scan the src directory and upload dependency results
       uses: anchore/sbom-action@v0
       with:
-        path: ./src/
+        path: ../..
         artifact-name: src.spdx.json
         dependency-snapshot: true
-


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
fix: use correct path in sbom workflow


## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
